### PR TITLE
feat(commands) add share command which opens a ngrok tunnel

### DIFF
--- a/bin/cli-default.js
+++ b/bin/cli-default.js
@@ -30,6 +30,10 @@ module.exports = co.wrap(function * () {
           name: 'Install most used npm packages',
           value: 'packages'
         },
+        {
+          name: 'Share your local version',
+          value: 'share'
+        },
         new inquirer.Separator(),
         {
           name: 'Get me out!',

--- a/bin/cli-share.js
+++ b/bin/cli-share.js
@@ -1,0 +1,30 @@
+const chalk = require('chalk')
+const inquirer = require('inquirer')
+const co = require('co')
+const runShare = require('../src/commands/share')
+const _ = require('lodash')
+
+module.exports = co.wrap(function * (input, flags) {
+  let options = { port: 8080 },
+    answer
+
+  if (flags.port) {
+    answer = yield inquirer.prompt([
+      {
+        type: 'input',
+        name: 'port',
+        message: 'Which port do you want to share?',
+        validate: function (answer) {
+          return answer !== ''
+        }
+      }
+    ])
+  }
+
+  options = _.merge(options, answer)
+
+  return runShare(options).catch(err => {
+    console.error(chalk.red(err.stack))
+    return
+  })
+})

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -14,5 +14,6 @@ cli.command('component', 'Create a new component')
 cli.command('store', 'Create a new Vuex store module')
 cli.command('page', 'Create a new page')
 cli.command('packages', 'Install most used npm packages')
+cli.command('share', 'Share the current local revision with Ngrok')
 
 cli.parse()

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "lodash": "^4.17.4",
     "node-emoji": "^1.4.3",
     "ora": "^0.3.0",
-    "path-exists": "^3.0.0"
+    "path-exists": "^3.0.0",
+    "ngrok": "^2.2.4"
   },
   "devDependencies": {
     "eslint": "^3.12.2",

--- a/src/commands/share.js
+++ b/src/commands/share.js
@@ -1,0 +1,24 @@
+const ngrok = require('ngrok')
+const chalk = require('chalk')
+const ora = require('ora')
+const co = require('co')
+
+const spinner = ora()
+
+module.exports = co.wrap(function (input) {
+  spinner.text = 'Sharing a new demo'
+  spinner.start()
+
+  ngrok.connect(input, function (error, url) {
+    if (error) {
+      spinner.fail()
+      console.error(chalk.red('Share failed'))
+
+      return
+    }
+
+    spinner.succeed()
+    console.log(chalk.bold(`Sharing a new demo:`))
+    console.log(chalk.italic(`${url}`))
+  })
+})


### PR DESCRIPTION
This will enable users to share a demo of the current revision at any time, similar to `valet share` which is laravel specific. It will open a tunnel to localhost of the user, this is very useful for testing in different browsers, or to discuss behavior with another person (project manager, client, designer etc.)